### PR TITLE
[fix]: introduce scoll in monitoring pages to cover all rows

### DIFF
--- a/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
+++ b/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
@@ -238,7 +238,7 @@ const Matrix: FC<MatrixProps> = ({
   isMonitoringActive,
   showRouteDetails
 }) => (
-  <TableContainer style={{ maxHeight: '100vh', overflowY: 'hidden' }}>
+  <TableContainer style={{ maxHeight: '70vh', overflowY: 'scroll' }}>
     <Table stickyHeader>
       <TableHead>
         <TableRow>


### PR DESCRIPTION
**What was the issue ?**
The table height in the monitoring pages was fixed to 100vh, due to this all the rows were not visible properly.

**What does this PR do?**
Solves #341 
- [x] Add a scroll in the table so as to cover all the rows. 