### PR TITLE
Fix overflow of routes in Monitoring Matrix

### DIFF
--- a/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
+++ b/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
@@ -18,7 +18,7 @@ import CircularProgress from '@material-ui/core/CircularProgress';
 import WarningOutlinedIcon from '@material-ui/icons/WarningOutlined';
 import ArrowForwardIcon from '@material-ui/icons/ArrowForward';
 import Tooltip from '@material-ui/core/Tooltip';
-
+import { truncate } from '../../utils/stringManipulations';
 import { Badge } from 'reactstrap';
 
 type APIResponse<MatrixResponse> = { status: string; data: MatrixResponse };
@@ -137,12 +137,16 @@ const Element: FC<ElementProps> = ({
   return (
     <TableRow>
       <TableCell
-        style={{ maxWidth: 240, fontSize: 16, overflowX: 'hidden' }}
+        style={{
+          maxWidth: 240,
+          fontSize: 16,
+          overflowX: 'hidden'
+        }}
         align="left"
       >
         <Badge color="light">
           <Tooltip title={timeSeriesPath.name}>
-            <div>{timeSeriesPath.name}</div>
+            <div>{truncate(timeSeriesPath.name, 40)}</div>
           </Tooltip>
         </Badge>
       </TableCell>


### PR DESCRIPTION
### **What was the issue ?**
The routes were overflowing in some browser and was working fine in others.

### **Before**
![Screenshot from 2021-03-13 13-37-49](https://user-images.githubusercontent.com/56596436/111025457-49586000-840a-11eb-84fc-6147316d325c.png)

### **After**
![Screenshot from 2021-03-13 14-42-50](https://user-images.githubusercontent.com/56596436/111025496-80c70c80-840a-11eb-9334-9dbe5af99b0c.png)


### **What does it do?**
fixes #279 