### PR TITLE
Add heading to Monitoring page of individual routes

### DIFF
--- a/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
+++ b/dashboard/v1.1/src/pages/Monitoring/Matrix.tsx
@@ -67,7 +67,7 @@ const Element: FC<ElementProps> = ({
     });
 
     const details = await monitoringDetails;
-    showRouteDetails(true, details);
+    showRouteDetails(true, { ...details, name: instance.name });
   };
 
   useEffect(() => {

--- a/dashboard/v1.1/src/pages/Monitoring/RouteDetails.tsx
+++ b/dashboard/v1.1/src/pages/Monitoring/RouteDetails.tsx
@@ -5,13 +5,13 @@ import ResLength from './ResLength';
 import Delay from './Delay';
 import Ping from './Ping';
 import Jitter from './Jitter';
-
 import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import PropTypes from 'prop-types';
 import Box from '@material-ui/core/Box';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
+import { truncate } from '../../utils/stringManipulations';
 
 interface RouteDetailsProps {
   routesChains: RouteDetails;
@@ -54,6 +54,7 @@ const format = (data: RouteDetails) => {
   const pingMean: chartData[] = [];
   const pingMax: chartData[] = [];
   const jitter: chartData[] = [];
+  const name = data.name;
 
   for (const value of data.monitor.values) {
     responseDetailsDelay.push({
@@ -92,7 +93,8 @@ const format = (data: RouteDetails) => {
     pingMin,
     pingMean,
     pingMax,
-    jitter
+    jitter,
+    name
   };
 };
 
@@ -107,8 +109,22 @@ const RouteDetailsComponent: FC<RouteDetailsProps> = ({
   const data = format(routesChains);
   return (
     <>
-      <span onClick={() => showDetails(false, routesChains)}>
+      <span
+        style={{ display: 'flex', alignItems: 'center' }}
+        onClick={() => showDetails(false, routesChains)}
+      >
         <ArrowBackIcon color="primary" fontSize="large" />
+        <span
+          style={{
+            fontSize: '1rem',
+            fontWeight: 'bold',
+            padding: '0 0.4rem',
+            display: 'flex',
+            alignItems: 'center'
+          }}
+        >
+          {truncate(data.name, 70)}
+        </span>
       </span>
       <hr />
       <AppBar position="static">

--- a/dashboard/v1.1/src/utils/queryTypes.ts
+++ b/dashboard/v1.1/src/utils/queryTypes.ts
@@ -115,4 +115,5 @@ export interface RouteDetails {
   ping: QueryResponse;
   jitter: QueryResponse;
   monitor: QueryResponse;
+  name: string;
 }


### PR DESCRIPTION
Signed-off-by: ruddi <rudrakshaggarwalsachin@gmail.com>

Problem Solved
In the monitoring screen, a user can click on the forward arrow button to check on the details of a particular route. But due to the absence of any heading of which route has been clicked, it creates confusion and misleading for the user.

After-
![Screenshot from 2021-03-13 17-36-04](https://user-images.githubusercontent.com/56596436/111029711-1753f780-8424-11eb-88a9-83e0b68a62b2.png)


fixes #344 