### PR TITLE
fix: reset button sets default values

### DIFF
--- a/dashboard/v1.1/src/pages/Input/Input.tsx
+++ b/dashboard/v1.1/src/pages/Input/Input.tsx
@@ -56,15 +56,16 @@ const Input = (props: InputScreenProps) => {
     labels,
     updateCurrentModal
   } = props;
-  const [requestType, setRequestType] = useState(
-    defaultRequestMethodsList[0].value
-  );
-  const [hyperTextType, setHyperTextType] = useState(
-    defaultHTTPMethodsList[1].value
-  );
-  const [valueURLRoute, setValueURLRoute] = useState(
-    `${defaultHTTPMethodsList[1].value.toLowerCase()}://`
-  );
+
+  const INITIAL_STATE = {
+    REQUEST_TYPE: defaultRequestMethodsList[0].value,
+    HTTP_METHOD: defaultHTTPMethodsList[1].value,
+    URL_ROUTE: `${defaultHTTPMethodsList[1].value.toLowerCase()}://`
+  };
+
+  const [requestType, setRequestType] = useState(INITIAL_STATE.REQUEST_TYPE);
+  const [hyperTextType, setHyperTextType] = useState(INITIAL_STATE.HTTP_METHOD);
+  const [valueURLRoute, setValueURLRoute] = useState(INITIAL_STATE.URL_ROUTE);
 
   const [applyHeader, setApplyHeader] = useState<boolean>(false);
   const [headerValues, setHeaderValues] = useState<pair[]>();
@@ -123,9 +124,9 @@ const Input = (props: InputScreenProps) => {
   };
   const handleCancel = () => {
     setShowResponseButton(false);
-    setRequestType('');
-    setHyperTextType('');
-    setValueURLRoute('');
+    setRequestType(INITIAL_STATE.REQUEST_TYPE);
+    setHyperTextType(INITIAL_STATE.HTTP_METHOD);
+    setValueURLRoute(INITIAL_STATE.URL_ROUTE);
     setHeaderValues([]);
     setParamsValues([]);
     setBodyValues([]);


### PR DESCRIPTION
Signed-off-by: sachdeva-shrey <shreysachdeva.2000@gmail.com>

Fixes https://github.com/bench-routes/bench-routes/issues/373

## Changes
- Set default values of `requestType`, `hyperTextType` & `valueURLRoute` when clicked on Reset.

## Screenshots
![Bench-routes (1)](https://user-images.githubusercontent.com/47667325/111415051-2b8b4380-8707-11eb-86a5-52f54e91d933.gif)

