### PR TITLE
Remove outline of buttons

### DIFF
--- a/dashboard/v1.1/src/App.css
+++ b/dashboard/v1.1/src/App.css
@@ -7,6 +7,10 @@
   pointer-events: none;
 }
 
+button:focus {
+  outline: 0px !important;
+}
+
 @media (prefers-reduced-motion: no-preference) {
   .App-logo {
     animation: App-logo-spin infinite 20s linear;
@@ -42,5 +46,5 @@
 }
 
 .inner-head {
-  margin: '2% 0% 2% 0%'
+  margin: '2% 0% 2% 0%';
 }

--- a/dashboard/v1.1/src/pages/Dashboard/JournalMetrics.tsx
+++ b/dashboard/v1.1/src/pages/Dashboard/JournalMetrics.tsx
@@ -189,8 +189,8 @@ const JournalMetrics: FC<{}> = () => {
     <div className={classes.root}>
       <AppBar position="static">
         <Tabs value={value} onChange={handleChange} indicatorColor="secondary">
-          <Tab label="Kernel" {...a11yProps(0)} style={{ outline: '0px' }} />
-          <Tab label="Systemd" {...a11yProps(1)} style={{ outline: '0px' }} />
+          <Tab label="Kernel" {...a11yProps(0)} />
+          <Tab label="Systemd" {...a11yProps(1)} />
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>

--- a/dashboard/v1.1/src/pages/Dashboard/SystemMetrics.tsx
+++ b/dashboard/v1.1/src/pages/Dashboard/SystemMetrics.tsx
@@ -171,17 +171,9 @@ const SystemMetrics: FC<SystemMetricsProps> = ({ showLoader }) => {
               onChange={handleChange}
               indicatorColor="secondary"
             >
-              <Tab
-                label="System"
-                {...a11yProps(0)}
-                style={{ outline: '0px' }}
-              />
-              <Tab label="Disk" {...a11yProps(1)} style={{ outline: '0px' }} />
-              <Tab
-                label="Memory details"
-                {...a11yProps(2)}
-                style={{ outline: '0px' }}
-              />
+              <Tab label="System" {...a11yProps(0)} />
+              <Tab label="Disk" {...a11yProps(1)} />
+              <Tab label="Memory details" {...a11yProps(2)} />
             </Tabs>
           </AppBar>
           <TabPanel value={value} index={0}>

--- a/dashboard/v1.1/src/pages/Monitoring/RouteDetails.tsx
+++ b/dashboard/v1.1/src/pages/Monitoring/RouteDetails.tsx
@@ -135,18 +135,10 @@ const RouteDetailsComponent: FC<RouteDetailsProps> = ({
       <hr />
       <AppBar position="static">
         <Tabs value={value} onChange={handleChange} indicatorColor="secondary">
-          <Tab
-            label="Response length"
-            {...a11yProps(0)}
-            style={{ outline: 0 }}
-          />
-          <Tab
-            label="Response delay"
-            {...a11yProps(1)}
-            style={{ outline: 0 }}
-          />
-          <Tab label="Ping" {...a11yProps(2)} style={{ outline: 0 }} />
-          <Tab label="Jitter" {...a11yProps(3)} style={{ outline: 0 }} />
+          <Tab label="Response length" {...a11yProps(0)} />
+          <Tab label="Response delay" {...a11yProps(1)} />
+          <Tab label="Ping" {...a11yProps(2)} />
+          <Tab label="Jitter" {...a11yProps(3)} />
         </Tabs>
       </AppBar>
       <TabPanel value={value} index={0}>


### PR DESCRIPTION
Signed-off-by: ruddi <rudrakshaggarwalsachin@gmail.com>
Remove the outline from button when they are focused this problem wasnt limited to just Quick Input but also to the tab of the graph tables although #350 fixes them the code was a bit repetetive and this might occur in other components in future too so I went for a different solution. The cause of this problem was a css property applied by default on button elements by the browser.
fixes #390 
### **Solution**
![Peek 2021-03-19 22-50](https://user-images.githubusercontent.com/56596436/111819194-1597a180-8906-11eb-826d-aac2ce45dde0.gif)

### **Caused due to-**
![Screenshot from 2021-03-19 22-33-54](https://user-images.githubusercontent.com/56596436/111819562-7d4dec80-8906-11eb-9efc-756aec59459f.png)

