### PR TITLE
Quick-input icon Redesigning

### DIFF
--- a/dashboard/v1.1/src/App.css
+++ b/dashboard/v1.1/src/App.css
@@ -57,3 +57,7 @@ a.MuiButtonBase-root.MuiListItem-root:hover {
   color: inherit;
   background-color: rgba(172, 172, 172, 0.685);
 }
+
+.makeStyles-inputFab-22:hover {
+  transform: translateX(0);
+}

--- a/dashboard/v1.1/src/layouts/QuickInputFab.tsx
+++ b/dashboard/v1.1/src/layouts/QuickInputFab.tsx
@@ -7,7 +7,7 @@ const useStyles = makeStyles(theme => ({
   inputFab: {
     position: 'fixed',
     right: 0,
-    bottom: '4.5rem',
+    bottom: '10rem',
     borderRadius: '10px 0 0 10px',
     width: '10rem',
     height: '3rem',

--- a/dashboard/v1.1/src/layouts/QuickInputFab.tsx
+++ b/dashboard/v1.1/src/layouts/QuickInputFab.tsx
@@ -6,8 +6,18 @@ import { Link } from 'react-router-dom';
 const useStyles = makeStyles(theme => ({
   inputFab: {
     position: 'fixed',
-    right: '2rem',
-    bottom: '2rem'
+    right: 0,
+    bottom: '4.5rem',
+    borderRadius: '10px 0 0 10px',
+    width: '10rem',
+    height: '3rem',
+    zIndex: 12,
+    transform: 'translateX(70%)',
+    transition: '0.3s all ease-in'
+  },
+  tag: {
+    fontWeight: 600,
+    padding: 15
   }
 }));
 
@@ -23,6 +33,7 @@ const QuickInputFab = () => {
           aria-label="quick-input"
         >
           <PostAddIcon />
+          <span className={classes.tag}>Quick Input</span>
         </Fab>
       </Tooltip>
     </Link>


### PR DESCRIPTION
Signed-off-by: Tushar3099 <tusharneogi30@gmail.com>

Fixes Issue: #399

**Type Of Change**
----

- [x] Bug


**Changes**
----

- Redesigned Quick-input Icon.
- When we hover over the icon, it slides out as Quick-Input.

**Preview**
----

https://user-images.githubusercontent.com/51849085/111923182-fa729080-8ac3-11eb-9b83-8ef182aa028c.mp4


