### PR TITLE
Querying unflushed-memory-chain

### DIFF
--- a/dashboard/v1.1/src/pages/Dashboard/JournalMetrics.tsx
+++ b/dashboard/v1.1/src/pages/Dashboard/JournalMetrics.tsx
@@ -75,9 +75,7 @@ const JournalMetrics: FC<{}> = () => {
     setValue(newValue);
   };
   useEffect(() => {
-    fetch(
-      `${HOST_IP}/query?timeSeriesPath=storage/journal&endTimestamp=${endTimestamp}`
-    )
+    fetch(`${HOST_IP}/query?type=journal&endTimestamp=${endTimestamp}`)
       .then(res => res.json())
       .then(
         (response: APIResponse<QueryResponse>) => {

--- a/dashboard/v1.1/src/pages/Dashboard/SystemMetrics.tsx
+++ b/dashboard/v1.1/src/pages/Dashboard/SystemMetrics.tsx
@@ -128,9 +128,7 @@ const SystemMetrics: FC<SystemMetricsProps> = ({ showLoader }) => {
     showLoader(true);
   }, [showLoader]);
   useEffect(() => {
-    fetch(
-      `${HOST_IP}/query?timeSeriesPath=storage/system&endTimestamp=${endTimestamp}`
-    )
+    fetch(`${HOST_IP}/query?type=system&endTimestamp=${endTimestamp}`)
       .then(res => res.json())
       .then(
         (response: APIResponse<QueryResponse>) => {

--- a/dashboard/v1.1/src/pages/Jitter/JitterModule.tsx
+++ b/dashboard/v1.1/src/pages/Jitter/JitterModule.tsx
@@ -66,9 +66,7 @@ const JitterModule: FC<{}> = () => {
   async function getChartsData(v: string) {
     try {
       const response = await fetch(
-        `${HOST_IP}/query?timeSeriesPath=storage/jitter/chunk_jitter_${hashRoutMap.get(
-          v
-        )}`
+        `${HOST_IP}/query?hashKey=${hashRoutMap.get(v)}&type=jitter`
       );
       const matrix = (await response.json()) as APIQueryResponse;
       var formatdata = format(matrix.data);

--- a/dashboard/v1.1/src/pages/Ping/PingModule.tsx
+++ b/dashboard/v1.1/src/pages/Ping/PingModule.tsx
@@ -80,9 +80,7 @@ const PingModule: FC<{}> = () => {
   async function getChartsData(v: string) {
     try {
       const response = await fetch(
-        `${HOST_IP}/query?timeSeriesPath=storage/ping/chunk_ping_${hashRoutMap.get(
-          v
-        )}`
+        `${HOST_IP}/query?hashKey=${hashRoutMap.get(v)}&type=ping`
       );
       const matrix = (await response.json()) as APIQueryResponse;
       var formatdata = format(matrix.data);

--- a/tsdb/db.go
+++ b/tsdb/db.go
@@ -309,8 +309,11 @@ func (c *ChainReadOnly) Refresh() *ChainReadOnly {
 	response, err := parse(c.Path)
 	if err != nil {
 		log.Errorf("error reading the chain: %s\n", c.Path)
+		empty := ""
+		c.Chain = loadFromStorage(&empty)
+	} else {
+		c.Chain = loadFromStorage(response)
 	}
-	c.Chain = loadFromStorage(response)
 	return c
 }
 

--- a/tsdb/querier/querier.go
+++ b/tsdb/querier/querier.go
@@ -88,9 +88,10 @@ func (q *Query) Exec() []byte {
 
 // ExecWithoutEncode executes the Query without encoding the result to []byte,
 // rather keeps the result as default QueryResponse.
-func (q *Query) ExecWithoutEncode() QueryResponse {
+func (q *Query) ExecWithoutEncode(newBlocks []tsdb.Block) QueryResponse {
 	chainReadOnly := tsdb.ReadOnly(q.Path).Refresh()
 	bstream := chainReadOnly.BlockStream()
+	*bstream = append(*bstream, newBlocks...)
 	data, _ := q.exec(*bstream, false).(QueryResponse)
 	return data
 }


### PR DESCRIPTION
Signed-off-by: Tushar3099 <tusharneogi30@gmail.com>

Fixes Issue: #378 

**Type Of Change**
----

- [x] Enhancement


**Changes**
----
- Modified `ExecWithoutEncode` function to append in-memory chain to the chain retrieved from the secondary storage.
- Modified `/query` and `/query-matrix` route handlers to access the in-memory chains and pass it to `ExecWithoutEncode`
- Modified frontend fetch routes accordingly.

**Results**
- Querying in-memory chain in `Monitoring` window and `Test` window.

**Preview**
----

https://user-images.githubusercontent.com/51849085/112421453-0d4fc400-8d55-11eb-865f-96bc8d36ddc7.mp4

