### PR TITLE
Ping sleep enhancement

### DIFF
--- a/tests/loadFromStorage_testdata/test-chunk.json
+++ b/tests/loadFromStorage_testdata/test-chunk.json
@@ -1,1 +1,92 @@
-[{"datapoint":"2.022222","normalized-time":1574141875729125904,"type":"jitter","timestamp":"2019|November|19|11|7|55#1574141875729"},{"datapoint":"1.900000","normalized-time":1574141897926356508,"type":"jitter","timestamp":"2019|November|19|11|8|17#1574141897926"},{"datapoint":"6.044444","normalized-time":1574141934475859494,"type":"jitter","timestamp":"2019|November|19|11|8|54#1574141934475"},{"datapoint":"5.766667","normalized-time":1574141971457738487,"type":"jitter","timestamp":"2019|November|19|11|9|31#1574141971457"},{"datapoint":"0.544444","normalized-time":1574141993659858184,"type":"jitter","timestamp":"2019|November|19|11|9|53#1574141993659"},{"datapoint":"0.911111","normalized-time":1574142204556213591,"type":"jitter","timestamp":"2019|November|19|11|13|24#1574142204556"},{"datapoint":"2.133333","normalized-time":1574142226752450965,"type":"jitter","timestamp":"2019|November|19|11|13|46#1574142226752"},{"datapoint":"4.088889","normalized-time":1574142248952706125,"type":"jitter","timestamp":"2019|November|19|11|14|8#1574142248952"},{"datapoint":"2.388889","normalized-time":1574142271233124532,"type":"jitter","timestamp":"2019|November|19|11|14|31#1574142271233"},{"datapoint":"112.780000","normalized-time":1574152320441055010,"type":"jitter","timestamp":"2019|November|19|14|2|0#1574152320441"},{"datapoint":"3.788889","normalized-time":1574178466791428306,"type":"jitter","timestamp":"2019|November|19|21|17|46#1574178466791"},{"datapoint":"1.833333","normalized-time":1574178488986450408,"type":"jitter","timestamp":"2019|November|19|21|18|8#1574178488986"},{"datapoint":"16.533333","normalized-time":1574178633720725170,"type":"jitter","timestamp":"2019|November|19|21|20|33#1574178633720"},{"datapoint":"5.411111","normalized-time":1574178652972504695,"type":"jitter","timestamp":"2019|November|19|21|20|52#1574178652972"},{"datapoint":"7.077778","normalized-time":1574178672171188578,"type":"jitter","timestamp":"2019|November|19|21|21|12#1574178672171"}]
+[
+    {
+        "datapoint": "2.022222",
+        "normalized-time": 1574141875729125904,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|7|55#1574141875729"
+    },
+    {
+        "datapoint": "1.900000",
+        "normalized-time": 1574141897926356508,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|8|17#1574141897926"
+    },
+    {
+        "datapoint": "6.044444",
+        "normalized-time": 1574141934475859494,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|8|54#1574141934475"
+    },
+    {
+        "datapoint": "5.766667",
+        "normalized-time": 1574141971457738487,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|9|31#1574141971457"
+    },
+    {
+        "datapoint": "0.544444",
+        "normalized-time": 1574141993659858184,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|9|53#1574141993659"
+    },
+    {
+        "datapoint": "0.911111",
+        "normalized-time": 1574142204556213591,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|13|24#1574142204556"
+    },
+    {
+        "datapoint": "2.133333",
+        "normalized-time": 1574142226752450965,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|13|46#1574142226752"
+    },
+    {
+        "datapoint": "4.088889",
+        "normalized-time": 1574142248952706125,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|14|8#1574142248952"
+    },
+    {
+        "datapoint": "2.388889",
+        "normalized-time": 1574142271233124532,
+        "type": "jitter",
+        "timestamp": "2019|November|19|11|14|31#1574142271233"
+    },
+    {
+        "datapoint": "112.780000",
+        "normalized-time": 1574152320441055010,
+        "type": "jitter",
+        "timestamp": "2019|November|19|14|2|0#1574152320441"
+    },
+    {
+        "datapoint": "3.788889",
+        "normalized-time": 1574178466791428306,
+        "type": "jitter",
+        "timestamp": "2019|November|19|21|17|46#1574178466791"
+    },
+    {
+        "datapoint": "1.833333",
+        "normalized-time": 1574178488986450408,
+        "type": "jitter",
+        "timestamp": "2019|November|19|21|18|8#1574178488986"
+    },
+    {
+        "datapoint": "16.533333",
+        "normalized-time": 1574178633720725170,
+        "type": "jitter",
+        "timestamp": "2019|November|19|21|20|33#1574178633720"
+    },
+    {
+        "datapoint": "5.411111",
+        "normalized-time": 1574178652972504695,
+        "type": "jitter",
+        "timestamp": "2019|November|19|21|20|52#1574178652972"
+    },
+    {
+        "datapoint": "7.077778",
+        "normalized-time": 1574178672171188578,
+        "type": "jitter",
+        "timestamp": "2019|November|19|21|21|12#1574178672171"
+    }
+]

--- a/tests/loadFromStorage_testdata/test1.json
+++ b/tests/loadFromStorage_testdata/test1.json
@@ -1,1 +1,266 @@
-[{"datapoint":"413|-1|200","normalized-time":1575315899023272261,"type":"req-res","timestamp":"2019|December|3|1|14|59#1575315899023"},{"datapoint":"143|-1|200","normalized-time":1575315899305733698,"type":"req-res","timestamp":"2019|December|3|1|14|59#1575315899305"},{"datapoint":"666|-1|200","normalized-time":1575318308231038195,"type":"req-res","timestamp":"2019|December|3|1|55|8#1575318308231"},{"datapoint":"414|-1|200","normalized-time":1575318426254112818,"type":"req-res","timestamp":"2019|December|3|1|57|6#1575318426254"},{"datapoint":"387|-1|200","normalized-time":1575318623152023910,"type":"req-res","timestamp":"2019|December|3|2|0|23#1575318623152"},{"datapoint":"204|-1|200","normalized-time":1575318623472907238,"type":"req-res","timestamp":"2019|December|3|2|0|23#1575318623472"},{"datapoint":"154|-1|200","normalized-time":1575318623690521073,"type":"req-res","timestamp":"2019|December|3|2|0|23#1575318623690"},{"datapoint":"143|-1|200","normalized-time":1575318623966295284,"type":"req-res","timestamp":"2019|December|3|2|0|23#1575318623966"},{"datapoint":"152|-1|200","normalized-time":1575318624241235787,"type":"req-res","timestamp":"2019|December|3|2|0|24#1575318624241"},{"datapoint":"154|-1|200","normalized-time":1575318624518648446,"type":"req-res","timestamp":"2019|December|3|2|0|24#1575318624518"},{"datapoint":"143|-1|200","normalized-time":1575318624812630188,"type":"req-res","timestamp":"2019|December|3|2|0|24#1575318624812"},{"datapoint":"150|-1|200","normalized-time":1575318625209262940,"type":"req-res","timestamp":"2019|December|3|2|0|25#1575318625209"},{"datapoint":"140|-1|200","normalized-time":1575318625463384871,"type":"req-res","timestamp":"2019|December|3|2|0|25#1575318625463"},{"datapoint":"245|-1|200","normalized-time":1575318625831270262,"type":"req-res","timestamp":"2019|December|3|2|0|25#1575318625831"},{"datapoint":"206|-1|200","normalized-time":1575318626056671139,"type":"req-res","timestamp":"2019|December|3|2|0|26#1575318626056"},{"datapoint":"151|-1|200","normalized-time":1575318626249687835,"type":"req-res","timestamp":"2019|December|3|2|0|26#1575318626249"},{"datapoint":"151|-1|200","normalized-time":1575318626509534272,"type":"req-res","timestamp":"2019|December|3|2|0|26#1575318626509"},{"datapoint":"162|-1|200","normalized-time":1575318626786403132,"type":"req-res","timestamp":"2019|December|3|2|0|26#1575318626786"},{"datapoint":"217|-1|200","normalized-time":1575318627103694960,"type":"req-res","timestamp":"2019|December|3|2|0|27#1575318627103"},{"datapoint":"149|-1|200","normalized-time":1575318627303918342,"type":"req-res","timestamp":"2019|December|3|2|0|27#1575318627303"},{"datapoint":"155|-1|200","normalized-time":1575318627568498326,"type":"req-res","timestamp":"2019|December|3|2|0|27#1575318627568"},{"datapoint":"204|-1|200","normalized-time":1575318627896054258,"type":"req-res","timestamp":"2019|December|3|2|0|27#1575318627896"},{"datapoint":"146|-1|200","normalized-time":1575318628107535019,"type":"req-res","timestamp":"2019|December|3|2|0|28#1575318628107"},{"datapoint":"149|-1|200","normalized-time":1575318628370201650,"type":"req-res","timestamp":"2019|December|3|2|0|28#1575318628370"},{"datapoint":"152|-1|200","normalized-time":1575318628639052044,"type":"req-res","timestamp":"2019|December|3|2|0|28#1575318628639"},{"datapoint":"140|-1|200","normalized-time":1575318628893017974,"type":"req-res","timestamp":"2019|December|3|2|0|28#1575318628893"},{"datapoint":"269|-1|200","normalized-time":1575318629298508223,"type":"req-res","timestamp":"2019|December|3|2|0|29#1575318629298"},{"datapoint":"141|-1|200","normalized-time":1575318629440845311,"type":"req-res","timestamp":"2019|December|3|2|0|29#1575318629440"},{"datapoint":"146|-1|200","normalized-time":1575318629699717569,"type":"req-res","timestamp":"2019|December|3|2|0|29#1575318629699"},{"datapoint":"145|-1|200","normalized-time":1575318630010555781,"type":"req-res","timestamp":"2019|December|3|2|0|30#1575318630010"},{"datapoint":"151|-1|200","normalized-time":1575318630296107612,"type":"req-res","timestamp":"2019|December|3|2|0|30#1575318630296"},{"datapoint":"155|-1|200","normalized-time":1575318630558899804,"type":"req-res","timestamp":"2019|December|3|2|0|30#1575318630558"},{"datapoint":"154|-1|200","normalized-time":1575318630847880028,"type":"req-res","timestamp":"2019|December|3|2|0|30#1575318630847"},{"datapoint":"148|-1|200","normalized-time":1575318631108559730,"type":"req-res","timestamp":"2019|December|3|2|0|31#1575318631108"},{"datapoint":"154|-1|200","normalized-time":1575318631507854729,"type":"req-res","timestamp":"2019|December|3|2|0|31#1575318631507"},{"datapoint":"144|-1|200","normalized-time":1575318631768075249,"type":"req-res","timestamp":"2019|December|3|2|0|31#1575318631768"},{"datapoint":"147|-1|200","normalized-time":1575318632047367580,"type":"req-res","timestamp":"2019|December|3|2|0|32#1575318632047"},{"datapoint":"152|-1|200","normalized-time":1575318632458923674,"type":"req-res","timestamp":"2019|December|3|2|0|32#1575318632458"},{"datapoint":"151|-1|200","normalized-time":1575318632731423140,"type":"req-res","timestamp":"2019|December|3|2|0|32#1575318632731"},{"datapoint":"149|-1|200","normalized-time":1575318633004514350,"type":"req-res","timestamp":"2019|December|3|2|0|33#1575318633004"},{"datapoint":"157|-1|200","normalized-time":1575318633303474229,"type":"req-res","timestamp":"2019|December|3|2|0|33#1575318633303"},{"datapoint":"159|-1|200","normalized-time":1575318633568554744,"type":"req-res","timestamp":"2019|December|3|2|0|33#1575318633568"},{"datapoint":"145|-1|200","normalized-time":1575318633823909426,"type":"req-res","timestamp":"2019|December|3|2|0|33#1575318633823"},{"datapoint":"153|-1|200","normalized-time":1575318634093471595,"type":"req-res","timestamp":"2019|December|3|2|0|34#1575318634093"}]
+[
+    {
+        "datapoint": "413|-1|200",
+        "normalized-time": 1575315899023272261,
+        "type": "req-res",
+        "timestamp": "2019|December|3|1|14|59#1575315899023"
+    },
+    {
+        "datapoint": "143|-1|200",
+        "normalized-time": 1575315899305733698,
+        "type": "req-res",
+        "timestamp": "2019|December|3|1|14|59#1575315899305"
+    },
+    {
+        "datapoint": "666|-1|200",
+        "normalized-time": 1575318308231038195,
+        "type": "req-res",
+        "timestamp": "2019|December|3|1|55|8#1575318308231"
+    },
+    {
+        "datapoint": "414|-1|200",
+        "normalized-time": 1575318426254112818,
+        "type": "req-res",
+        "timestamp": "2019|December|3|1|57|6#1575318426254"
+    },
+    {
+        "datapoint": "387|-1|200",
+        "normalized-time": 1575318623152023910,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|23#1575318623152"
+    },
+    {
+        "datapoint": "204|-1|200",
+        "normalized-time": 1575318623472907238,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|23#1575318623472"
+    },
+    {
+        "datapoint": "154|-1|200",
+        "normalized-time": 1575318623690521073,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|23#1575318623690"
+    },
+    {
+        "datapoint": "143|-1|200",
+        "normalized-time": 1575318623966295284,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|23#1575318623966"
+    },
+    {
+        "datapoint": "152|-1|200",
+        "normalized-time": 1575318624241235787,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|24#1575318624241"
+    },
+    {
+        "datapoint": "154|-1|200",
+        "normalized-time": 1575318624518648446,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|24#1575318624518"
+    },
+    {
+        "datapoint": "143|-1|200",
+        "normalized-time": 1575318624812630188,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|24#1575318624812"
+    },
+    {
+        "datapoint": "150|-1|200",
+        "normalized-time": 1575318625209262940,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|25#1575318625209"
+    },
+    {
+        "datapoint": "140|-1|200",
+        "normalized-time": 1575318625463384871,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|25#1575318625463"
+    },
+    {
+        "datapoint": "245|-1|200",
+        "normalized-time": 1575318625831270262,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|25#1575318625831"
+    },
+    {
+        "datapoint": "206|-1|200",
+        "normalized-time": 1575318626056671139,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|26#1575318626056"
+    },
+    {
+        "datapoint": "151|-1|200",
+        "normalized-time": 1575318626249687835,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|26#1575318626249"
+    },
+    {
+        "datapoint": "151|-1|200",
+        "normalized-time": 1575318626509534272,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|26#1575318626509"
+    },
+    {
+        "datapoint": "162|-1|200",
+        "normalized-time": 1575318626786403132,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|26#1575318626786"
+    },
+    {
+        "datapoint": "217|-1|200",
+        "normalized-time": 1575318627103694960,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|27#1575318627103"
+    },
+    {
+        "datapoint": "149|-1|200",
+        "normalized-time": 1575318627303918342,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|27#1575318627303"
+    },
+    {
+        "datapoint": "155|-1|200",
+        "normalized-time": 1575318627568498326,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|27#1575318627568"
+    },
+    {
+        "datapoint": "204|-1|200",
+        "normalized-time": 1575318627896054258,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|27#1575318627896"
+    },
+    {
+        "datapoint": "146|-1|200",
+        "normalized-time": 1575318628107535019,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|28#1575318628107"
+    },
+    {
+        "datapoint": "149|-1|200",
+        "normalized-time": 1575318628370201650,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|28#1575318628370"
+    },
+    {
+        "datapoint": "152|-1|200",
+        "normalized-time": 1575318628639052044,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|28#1575318628639"
+    },
+    {
+        "datapoint": "140|-1|200",
+        "normalized-time": 1575318628893017974,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|28#1575318628893"
+    },
+    {
+        "datapoint": "269|-1|200",
+        "normalized-time": 1575318629298508223,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|29#1575318629298"
+    },
+    {
+        "datapoint": "141|-1|200",
+        "normalized-time": 1575318629440845311,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|29#1575318629440"
+    },
+    {
+        "datapoint": "146|-1|200",
+        "normalized-time": 1575318629699717569,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|29#1575318629699"
+    },
+    {
+        "datapoint": "145|-1|200",
+        "normalized-time": 1575318630010555781,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|30#1575318630010"
+    },
+    {
+        "datapoint": "151|-1|200",
+        "normalized-time": 1575318630296107612,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|30#1575318630296"
+    },
+    {
+        "datapoint": "155|-1|200",
+        "normalized-time": 1575318630558899804,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|30#1575318630558"
+    },
+    {
+        "datapoint": "154|-1|200",
+        "normalized-time": 1575318630847880028,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|30#1575318630847"
+    },
+    {
+        "datapoint": "148|-1|200",
+        "normalized-time": 1575318631108559730,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|31#1575318631108"
+    },
+    {
+        "datapoint": "154|-1|200",
+        "normalized-time": 1575318631507854729,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|31#1575318631507"
+    },
+    {
+        "datapoint": "144|-1|200",
+        "normalized-time": 1575318631768075249,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|31#1575318631768"
+    },
+    {
+        "datapoint": "147|-1|200",
+        "normalized-time": 1575318632047367580,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|32#1575318632047"
+    },
+    {
+        "datapoint": "152|-1|200",
+        "normalized-time": 1575318632458923674,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|32#1575318632458"
+    },
+    {
+        "datapoint": "151|-1|200",
+        "normalized-time": 1575318632731423140,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|32#1575318632731"
+    },
+    {
+        "datapoint": "149|-1|200",
+        "normalized-time": 1575318633004514350,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|33#1575318633004"
+    },
+    {
+        "datapoint": "157|-1|200",
+        "normalized-time": 1575318633303474229,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|33#1575318633303"
+    },
+    {
+        "datapoint": "159|-1|200",
+        "normalized-time": 1575318633568554744,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|33#1575318633568"
+    },
+    {
+        "datapoint": "145|-1|200",
+        "normalized-time": 1575318633823909426,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|33#1575318633823"
+    },
+    {
+        "datapoint": "153|-1|200",
+        "normalized-time": 1575318634093471595,
+        "type": "req-res",
+        "timestamp": "2019|December|3|2|0|34#1575318634093"
+    }
+]


### PR DESCRIPTION
Added functionality of sleep in individual ping go-routine, But this gives rise to the new problem as the outermost for loop will now run super-fast and burn unnecessary CPU cycles, the function *utils.VerifyConnection* also would make a network call in each iteration.
So @Harkishen-Singh, Is this the desirable behavior.