### PR TITLE
Individual go-routine sleep

### DIFF
--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -88,6 +88,7 @@ func (ps *Ping) perform(pingInterval TestInterval) {
 }
 
 func (ps *Ping) pingExec(urlRaw, machineHash string, packets int, wg *sync.WaitGroup, pingInterval TestInterval) {
+	defer wg.Done()
 	for {
 		switch ps.localConfig.Config.UtilsConf.ServicesSignal.Ping {
 		case "active":
@@ -102,11 +103,9 @@ func (ps *Ping) pingExec(urlRaw, machineHash string, packets int, wg *sync.WaitG
 			}
 		case "passive":
 			// terminate the goroutine
-			wg.Done()
 			return
 		default:
 			log.Warnln("invalid service-state value of ping")
-			wg.Done()
 			return
 		}
 


### PR DESCRIPTION
Signed-off-by: Tushar3099 <tusharneogi30@gmail.com>
fixes :  #61 

- [x]  Enhancement

**Changes**
-----
- In `ping.go` I have modified the perform function.
- Earlier perform function was running infinitely for all set of routes with sleeping duration.
- Now the perform functions execute `pingExec` function for all sets of routes and waits for them to complete.
- `pingExec` function runs infinitely for every route independent of other routes running in the background with sleep duration.
- `pingExec` executes the `ping` function as earlier.

**Expected**
-----
- Now ping for each route is executed independently from other routes running in the background.

Additional Context
-----
- The PR is not fully refactored. Once the approach is confirmed, will do the necessary changes.
