### PR TITLE
Tests Icon was not functional when Sidebar was minized, hence I made the most Optimum Fix

### DIFF
--- a/dashboard/v1.1/src/layouts/Sidebar.tsx
+++ b/dashboard/v1.1/src/layouts/Sidebar.tsx
@@ -116,7 +116,7 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
         <ListItemText primary="Monitoring" />
       </ListItem>
       <ListItem button={true} selected={selectedIndex >= 3}>
-        <ListItemIcon>
+        <ListItemIcon onClick={showTestList}>
           <NetworkCheckIcon />
         </ListItemIcon>
         <ListItemText primary="Tests" onClick={showTestList} />


### PR DESCRIPTION
#414 
In "dashboard/v1.1/src/layouts/Sidebar.tsx", In the line 119, I called the "showTestList" function when "NetworkCheckIcon" will be pressed.
All with just a single line fix!!!