### PR TITLE
Test expand icon fix

### DIFF
--- a/dashboard/v1.1/src/layouts/Sidebar.tsx
+++ b/dashboard/v1.1/src/layouts/Sidebar.tsx
@@ -85,7 +85,7 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
 
   const showTestList = () => {
     setTestListOpen(!testListOpen);
-    setExpand(false);
+    setExpand(!expand);
   };
 
   const handleListItemClick = (event, index) => {

--- a/dashboard/v1.1/src/layouts/Sidebar.tsx
+++ b/dashboard/v1.1/src/layouts/Sidebar.tsx
@@ -84,8 +84,8 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
   const [expand, setExpand] = useState(true);
 
   const showTestList = () => {
-    setTestListOpen(!testListOpen);
-    setExpand(!expand);
+    setTestListOpen(isOpen => !isOpen);
+    setExpand(prevExpand => !prevExpand);
   };
 
   const handleListItemClick = (event, index) => {
@@ -124,9 +124,9 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
         </ListItemIcon>
         <ListItemText primary="Tests" onClick={showTestList} />
         {expand ? (
-          <ExpandLessIcon onClick={showTestList} />
-        ) : (
           <ExpandMoreIcon onClick={showTestList} />
+        ) : (
+          <ExpandLessIcon onClick={showTestList} />
         )}
       </ListItem>
       {/* Nested List */}

--- a/dashboard/v1.1/src/layouts/Sidebar.tsx
+++ b/dashboard/v1.1/src/layouts/Sidebar.tsx
@@ -81,8 +81,11 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
   // Sidebar element
   const [testListOpen, setTestListOpen] = useState(false);
   const [selectedIndex, setSelectedIndex] = React.useState(0);
+  const [expand, setExpand] = useState(true);
+
   const showTestList = () => {
     setTestListOpen(!testListOpen);
+    setExpand(false);
   };
 
   const handleListItemClick = (event, index) => {
@@ -120,7 +123,7 @@ const Sidebar: FC<SidebarProps> = ({ handleDrawerClose, open }) => {
           <NetworkCheckIcon />
         </ListItemIcon>
         <ListItemText primary="Tests" onClick={showTestList} />
-        {open ? (
+        {expand ? (
           <ExpandLessIcon onClick={showTestList} />
         ) : (
           <ExpandMoreIcon onClick={showTestList} />


### PR DESCRIPTION
**#418** 
**bug** - Boolean "open" in "dashboard/v1.1/src/layouts/Sidebar.tsx" in line 126  never changed its value, so the transition between
ExpandMoreIcon and ExpandLessIcon was not functional.

**Fix** - I added a new state hook "expand" in line 84, set it's value initially to "true" and replaced this state with "open" in line 126, then with the function "showTestList"  in line 86, the state  of "expand" is changing to its opposite value "!expand"  in state function "setExpand" declared on line 84.
