### PR TITLE
sets high timeout while doing yarn build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ test: build
 
 ## Installs UI dependencies and builds the frontend.
 build-frontend:
-	cd dashboard/v1.1/ && yarn install && yarn build
+	cd dashboard/v1.1/ && yarn install --network-timeout 1000000 && yarn build
 
 ## Runs Golang unit tests without mentioning the skipped tests.
 test-non-verbose: build


### PR DESCRIPTION
Fixes a bug in the CI tests. See [Yarn #4890](https://github.com/yarnpkg/yarn/issues/4890)