### PR TITLE
GettingActualRouteFromParameter

### DIFF
--- a/src/lib/api/api.go
+++ b/src/lib/api/api.go
@@ -516,15 +516,10 @@ func (a *API) DeleteConfigRoutes(w http.ResponseWriter, r *http.Request) {
 	if err := r.ParseForm(); err != nil {
 		panic(err)
 	}
-	var req struct {
-		ActualRoute string `json:"actualRoute"`
-	}
-	decoder := json.NewDecoder(r.Body)
-	if err := decoder.Decode(&req); err != nil {
-		panic(err)
-	}
+	actualRoute := r.URL.Query().Get("actualRoute") // actualRoute parameter from the request.
+
 	for i, route := range a.config.Config.Routes {
-		if route.URL == req.ActualRoute {
+		if route.URL == actualRoute {
 			a.mux.Lock()
 			a.config.Config.Routes = append(a.config.Config.Routes[:i], a.config.Config.Routes[i+1:]...)
 			a.mux.Unlock()


### PR DESCRIPTION
Now the actualRoute is not parsed from request body. Its parsed from url parameter.
Fixes https://github.com/bench-routes/bench-routes/issues/487